### PR TITLE
Update README.md to have a link to py3 API project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Conjur Python API Client
+# Conjur Python2 API Client
 
 A Python2 client for the Conjur API.
+
+**If you are looking for Python3 API client, please go to our new project page at https://github.com/cyberark/conjur-api-python3.**
 
 **IMPORTANT: THIS API CLIENT IS NOT CURRENTLY ACTIVELY BEING SUPPORTED**
 
 ## Installation
 
 This Conjur Python2 API requires Python 2.7.  
-
-**If you are looking for Python3 API, you can find that project at https://github.com/cyberark/conjur-api-python3.**
 
 Install from [PyPI](https://pypi.python.org/pypi/Conjur)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Conjur Python API Client
 
-A Python client for the Conjur API.
+A Python2 client for the Conjur API.
 
 **IMPORTANT: THIS API CLIENT IS NOT CURRENTLY ACTIVELY BEING SUPPORTED**
 
 ## Installation
 
-The Conjur Python API requires Python 2.7.  While we love Python 3, Python 2.x is the priority because of its
-widespread use by DevOps tools such as Salt and Ansible.
+This Conjur Python2 API requires Python 2.7.  
+
+**If you are looking for Python3 API, you can find that project at https://github.com/cyberark/conjur-api-python3.**
 
 Install from [PyPI](https://pypi.python.org/pypi/Conjur)
 


### PR DESCRIPTION
This will enable people landing on this project to go to our py3 API project
page if they are looking for Python3-compatible API library. Without this,
there is no indication that we have python3 support.