### PR TITLE
Made a requirement for Python2 in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **Unreleased**
 
+* Add requirement to setup.py for Python version 2
 * Changes license to Apache 2.0
 
 **v0.3.2**

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 NAME = 'Conjur'
-VERSION = '0.4.4'
+VERSION = '0.4.5'
 
 try:
     import pypandoc
@@ -15,11 +15,12 @@ setup(
     name=NAME,
     version=VERSION,
     packages=find_packages(),
+    python_requires='<3',
     install_requires=open('requirements.txt').readlines(),
     package_data={},
     author='Jon Mason',
     author_email='jon@conjur.net',
-    description='Python client for the Conjur API',
+    description='Python2-only client for the Conjur v4 API',
     long_description=long_description,
     license='MIT',
     url='https://github.com/conjurinc/api-python',


### PR DESCRIPTION
Since we will be publishing a new package, we need to ensure that it's
clear that this package is for python2-only deployments. README
and setup.py to reflect this change.