### PR TITLE
Add metadata about setup.py long description markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     author_email='jon@conjur.net',
     description='Python2-only client for the Conjur v4 API',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     license='MIT',
     url='https://github.com/conjurinc/api-python',
     classifiers=[


### PR DESCRIPTION
Old code did not properly detect that we were using markdown so this
change ensures that we use the correct indicator.